### PR TITLE
Feat annotation

### DIFF
--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -114,6 +114,43 @@ impl From<Node<'_, '_>> for Unit {
         }
     }
 }
+/// Metadata for models
+///
+/// # Example
+///
+/// ```
+/// use roxmltree;
+/// use rust_sbml::Annotation;
+///
+///let anotation: Annotation = roxmltree::Document::parse(
+///     "<model extentUnits='substance' id='e_coli_core' metaid='e_coli_core' name='Escherichia coli str. K-12 substr. MG1655' substanceUnits='substance' timeUnits='time'>",
+/// )
+/// .unwrap()
+/// .descendants()
+/// .filter(|n| n.tag_name().name() == "model")
+/// .map(|n| Annotation::from(n)).next().unwrap();
+/// println!("{:?}", anotation);
+/// assert_eq!(
+///     anotation.name.unwrap(),
+///     "Escherichia coli str. K-12 substr. MG1655".to_string()
+/// );
+/// ```
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct Annotation {
+    pub id: Option<String>,
+    pub metaid: Option<String>,
+    pub name: Option<String>,
+}
+impl From<Node<'_, '_>> for Annotation {
+    fn from(value: Node<'_, '_>) -> Self {
+        Annotation {
+            id: unwrap_optional_str(value, "id"),
+            metaid: unwrap_optional_str(value, "metaid"),
+            name: unwrap_optional_str(value, "name"),
+        }
+    }
+}
+
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Compartment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ mod model;
 mod pyo;
 
 pub use base_types::{
-    Annotation, Compartment, Constraint, InitialAssignment, ListOfSpecies, ModelUnits, Parameter, Reaction,
-    Specie, SpeciesReference, Unit, UnitSId, UnitSidRef,
+    Annotation, Compartment, Constraint, InitialAssignment, ListOfSpecies, ModelUnits, Parameter,
+    Reaction, Specie, SpeciesReference, Unit, UnitSId, UnitSidRef,
 };
 
 pub use model::{parse_document, Model};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod model;
 mod pyo;
 
 pub use base_types::{
-    Compartment, Constraint, InitialAssignment, ListOfSpecies, ModelUnits, Parameter, Reaction,
+    Annotation, Compartment, Constraint, InitialAssignment, ListOfSpecies, ModelUnits, Parameter, Reaction,
     Specie, SpeciesReference, Unit, UnitSId, UnitSidRef,
 };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use std::collections::HashMap;
 
 use super::base_types::{
-    Compartment, Constraint, InitialAssignment, ModelUnits, Parameter, Reaction, Specie, Unit,
+    Annotation, Compartment, Constraint, InitialAssignment, ModelUnits, Parameter, Reaction, Specie, Unit,
     UnitSId,
 };
 
@@ -40,6 +40,7 @@ pub struct Model {
     pub unit_definitions: HL<HashMap<UnitSId, Unit>>,
     pub constraints: Vec<Constraint>,
     pub objectives: Vec<String>,
+    pub annotation: Annotation,
 }
 
 impl Model {
@@ -120,6 +121,10 @@ impl Model {
                 )
             })
             .collect();
+        let annotation: Annotation = raw_model
+            .descendants()
+            .filter(|n| n.tag_name().name() == "model")
+            .map(|n| Annotation::from(n)).next().unwrap();
         // Compartments
         let compartments: HashMap<String, Compartment> = raw_model
             .descendants()
@@ -199,6 +204,7 @@ impl Model {
             model_units,
             parameters,
             initial_assignments,
+            annotation,
             species,
             reactions,
             compartments,

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,8 @@ use pyo3::prelude::*;
 use std::collections::HashMap;
 
 use super::base_types::{
-    Annotation, Compartment, Constraint, InitialAssignment, ModelUnits, Parameter, Reaction, Specie, Unit,
-    UnitSId,
+    Annotation, Compartment, Constraint, InitialAssignment, ModelUnits, Parameter, Reaction,
+    Specie, Unit, UnitSId,
 };
 
 type HL<T> = HashMap<String, T>;
@@ -124,7 +124,9 @@ impl Model {
         let annotation: Annotation = raw_model
             .descendants()
             .filter(|n| n.tag_name().name() == "model")
-            .map(|n| Annotation::from(n)).next().unwrap();
+            .map(Annotation::from)
+            .next()
+            .unwrap();
         // Compartments
         let compartments: HashMap<String, Compartment> = raw_model
             .descendants()

--- a/src/pyo.rs
+++ b/src/pyo.rs
@@ -121,21 +121,21 @@ impl Model {
     fn id(&self) -> PyResult<String> {
         Ok(match self.annotation.id.to_owned() {
             Some(s) => s,
-            None => "".to_string()
+            None => "".to_string(),
         })
     }
     #[getter]
     fn metaid(&self) -> PyResult<String> {
         Ok(match self.annotation.metaid.to_owned() {
             Some(s) => s,
-            None => "".to_string()
+            None => "".to_string(),
         })
     }
     #[getter]
     fn name(&self) -> PyResult<String> {
         Ok(match self.annotation.name.to_owned() {
             Some(s) => s,
-            None => "".to_string()
+            None => "".to_string(),
         })
     }
 }

--- a/src/pyo.rs
+++ b/src/pyo.rs
@@ -117,6 +117,27 @@ impl Model {
     fn getObjectives(&self) -> PyResult<Vec<String>> {
         Ok(self.objectives.to_owned())
     }
+    #[getter]
+    fn id(&self) -> PyResult<String> {
+        Ok(match self.annotation.id.to_owned() {
+            Some(s) => s,
+            None => "".to_string()
+        })
+    }
+    #[getter]
+    fn metaid(&self) -> PyResult<String> {
+        Ok(match self.annotation.metaid.to_owned() {
+            Some(s) => s,
+            None => "".to_string()
+        })
+    }
+    #[getter]
+    fn name(&self) -> PyResult<String> {
+        Ok(match self.annotation.name.to_owned() {
+            Some(s) => s,
+            None => "".to_string()
+        })
+    }
 }
 
 #[pymodule]


### PR DESCRIPTION
* [x] Closes #1 
* [x] Test more models.
* [x] Check notes/metadata specification (or libSBML way of handling this).

### Description
Load basic metadata

### Implementation
Parse `<model>` and flush its contents into a new public `Annotation` struct. It has to be tested for more models, because it was not very clear for me if that's always the case. An alternative would be to have a `HashMap` or arbitrary _attributes: values_ in `<model>`, which may be more straightforward.