### PR TITLE
Refactor quickxml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,8 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-roxmltree = "0.10.1"
-serde = "1.0.116"
-serde_derive = "1.0.116"
-serde_plain = "0.3.0"
-mathml = "0.4.3"
+quick-xml = { version = "0.20.0", features = ["serialize"] }
+serde = { version = "1.0", features = [ "derive" ] }
 pyo3 = { version = "0.12.1", optional = true }
 
 [features]

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ coverage:
 # Tests aren't important for coverage
 ignore:
   - "tests"
+  - "src/pyo.rs"
 
 # Make less noisy comments
 comment:

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -3,6 +3,12 @@
 use pyo3::prelude::*;
 use serde::Deserialize;
 
+/// Combination of [`Unit`](./rust_sbml/struct.Unit.html).
+///
+/// The approach to defining units in SBML is compositional; for example,
+/// metre second −2 is constructed by combining
+/// an Unit object representing metre with another Unit object representing
+/// second −2.
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct UnitDefinition {
     pub id: Option<String>,
@@ -16,14 +22,21 @@ pub struct ListOfUnits {
     pub units: Vec<Unit>,
 }
 
+/// A Unit object represents a reference to a (possibly transformed) base unit
+/// (see [UnitSIdRef](./rust_sbml/enum.UnitSIdRef.html).
+///
+/// The attribute kind indicates the base unit, whereas the attributes
+/// exponent, scale and multiplier define how the base unit is being transformed.
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct Unit {
     pub kind: UnitSIdRef,
-    exponent: f64,
-    scale: i64,
-    multiplier: f64,
+    pub exponent: f64,
+    pub scale: i64,
+    pub multiplier: f64,
 }
 
+/// SBML provides predefined base units, gathered in [`UnitSId`](./rust_sbml/enum.UnitSId.html).
+/// Alternatively, one can use arbitrary `CustomUnit`s.
 #[derive(Debug, Deserialize, Hash, PartialEq, Eq, Clone)]
 #[serde(untagged)]
 pub enum UnitSIdRef {
@@ -31,6 +44,7 @@ pub enum UnitSIdRef {
     CustomUnit(String),
 }
 
+/// One of the predefined values of a base unit by SBML level 3.
 #[derive(Debug, Hash, PartialEq, Eq, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum UnitSId {
@@ -69,43 +83,98 @@ pub enum UnitSId {
     Second,
 }
 
+/// A compartment in SBML represents a bounded space in which species are located.
+///
+/// # Example
+///
+/// ```
+/// use quick_xml::de::from_str;
+/// use rust_sbml::Compartment;
+///
+/// let compartments: Vec<Compartment> = from_str(
+///     "<compartment id='Extracellular' spatialDimensions='3' size='1e-14' constant='true'/>
+///     <compartment id='PlasmaMembrane' spatialDimensions='2' size='1e-14' constant='true'/>
+///     <compartment id='Cytosol' spatialDimensions='3' size='1e-15' constant='true'/>"
+/// )
+/// .unwrap();
+/// assert!(compartments.iter()
+///     .any(|c| c.spatial_dimensions.unwrap() as i32 == 2));
+/// assert!(compartments.iter()
+///     .any(|c| c.id == "Cytosol"));
+/// assert!(compartments.iter()
+///     .all(|c| c.constant));
+/// ```
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Compartment {
-    units: Option<UnitSIdRef>,
+    pub units: Option<UnitSIdRef>,
     pub id: String,
     pub name: Option<String>,
-    spatial_dimensions: Option<f64>,
-    size: Option<f64>,
-    constant: bool,
+    pub spatial_dimensions: Option<f64>,
+    pub size: Option<f64>,
+    pub constant: bool,
 }
 
 /// A species in SBML refers to a pool of entities that
 /// ⁻ are considered indistinguishable from each other for the purposes of the model;
 /// - may participate in reactions;
 /// - are located in a specific compartment.
+///
+/// # Example
+///
+/// ```
+/// use quick_xml::de::from_str;
+/// use rust_sbml::Species;
+///
+/// let species: Vec<Species> = from_str(
+///     "<species id='Glucose' compartment='cell' initialConcentration='4'
+///     hasOnlySubstanceUnits='false' boundaryCondition='false' constant='false'/>"
+/// )
+/// .unwrap();
+/// assert_eq!(species[0].compartment, "cell");
+/// assert_eq!(species[0].initial_concentration.unwrap() as u8, 4);
+/// assert!(!species[0].constant);
+/// ```
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Species {
     pub id: String,
     pub compartment: String,
-    initial_concentration: Option<f64>,
-    initial_amount: Option<f64>,
-    substance_units: Option<UnitSIdRef>,
-    has_only_substance_units: bool,
+    pub initial_concentration: Option<f64>,
+    pub initial_amount: Option<f64>,
+    pub substance_units: Option<UnitSIdRef>,
+    pub has_only_substance_units: bool,
     pub boundary_condition: bool,
     pub constant: bool,
-    conversion_factor: Option<String>,
+    pub conversion_factor: Option<String>,
 }
 
+/// A Parameter is used in SBML to define a symbol associated with a value;
+/// this symbol can then be used in mathematical formulas in a model.
+///
+/// # Example
+/// ```
+/// use quick_xml::de::from_str;
+/// use rust_sbml::{Parameter, UnitSIdRef, UnitSId};
+///
+/// let parameter: Vec<Parameter> = from_str(
+///     "<parameter id=\"tau2\" value=\"3e-2\" units=\"second\" constant=\"true\"/>
+///     <parameter id=\"Km1\" value=\"10.7\" units=\"molesperlitre\" constant=\"true\"/>"
+/// )
+/// .unwrap();
+/// assert_eq!(
+///     parameter[0].units.to_owned().unwrap(),
+///     UnitSIdRef::SIUnit(UnitSId::Second)
+/// );
+/// assert_eq!(parameter[1].id, "Km1");
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, Deserialize, PartialEq, Clone, Default)]
 pub struct Parameter {
     pub id: String,
     pub value: Option<f64>,
-    units: Option<UnitSIdRef>,
+    pub units: Option<UnitSIdRef>,
     pub constant: bool,
 }
 
@@ -120,6 +189,32 @@ pub struct InitialAssignment {
     sbo_term: Option<String>,
 }
 
+/// Provide a way for reactions to define species as products and reactants.
+///
+/// # Example
+///
+/// ```
+/// use quick_xml::de::from_str;
+/// use rust_sbml::Reaction;
+///
+/// let reactions: Reaction = from_str(
+/// "<reaction id='J1' reversible='false' fbc:lowerFluxBound='-20'>
+///         <listOfReactants>
+///             <speciesReference species='X0' stoichiometry='2' constant='true'/>
+///             <speciesReference species='X1' stoichiometry='1' constant='true'/>
+/// </listOfReactants></reaction></listOfReactions></model>",
+/// )
+/// .unwrap();
+/// println!("{:?}", reactions);
+/// let mut specs_ref = reactions
+///     .list_of_reactants
+///     .species_references
+///     .iter();
+/// assert!(specs_ref
+///     .any(|specref| specref.species == "X0"));
+/// assert!(specs_ref
+///     .all(|specref| specref.constant));
+/// ```
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct SpeciesReference {
@@ -141,6 +236,7 @@ pub struct ListOfSpeciesReferences {
 /// A reaction in SBML represents any kind of process that can change the
 /// quantity of one or more species in a model. Examples of such processes can
 /// include transformation, transport, molecular interactions, and more.
+///
 /// TODO: implement KineticLaw
 ///
 /// # Example
@@ -182,6 +278,7 @@ pub struct Reaction {
     pub upper_bound: Option<String>,
 }
 
+/// TODO: MathML not integrated
 // #[derive(Debug, PartialEq)]
 // pub struct Function {
 //     math: MathNode,
@@ -192,18 +289,54 @@ pub struct Reaction {
 //     AssignmentRule { math: MathNode, variable: &'a str },
 //     RateRule { math: MathNode, variable: &'a str },
 // }
+
+/// The Constraint object is a mechanism for stating the assumptions under which
+/// a model is designed to operate.
+/// 
+/// TODO: MathML not integrated
 #[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct Constraint {
     // pub math: Option<MathNode>,
     pub message: String,
+    #[serde(rename = "sboTerm")]
+    pub sbo_term: Option<String>,
 }
 
+/// The Flux Balance Constraints package of SBML defines extensions for the 
+/// model, including the FBC Objective. 
+///
+/// # Example
+/// 
+/// ```
+/// use quick_xml::de::from_str;
+/// use rust_sbml::Objective;
+///
+/// let objectives: Vec<Objective> = from_str(
+/// "<fbc:objective fbc:id=\"obj1\" fbc:type=\"maximize\">
+///     <fbc:listOfFluxObjectives>
+///         <fbc:fluxObjective fbc:reaction=\"R101\" fbc:coefficient=\"1\"/>
+///     </fbc:listOfFluxObjectives>
+/// </fbc:objective>
+/// <fbc:objective fbc:id=\"obj2\" fbc:type=\"minimize\">
+///     <fbc:listOfFluxObjectives>
+///         <fbc:fluxObjective fbc:reaction=\"R102\" fbc:coefficient=\"-2.5\"/>
+///         <fbc:fluxObjective fbc:reaction=\"R103\" fbc:coefficient=\"1\"/>
+///     </fbc:listOfFluxObjectives>
+/// </fbc:objective>").unwrap();
+///
+/// objectives.iter().any(|o| o.sense == "maximize");
+/// objectives[1].list_of_flux_objectives.flux_objectives.iter().any(|r| r.reaction.to_owned().unwrap() == "R103");
+/// ```
 #[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct Objective {
     #[serde(rename = "fbc:id")]
-    pub id: Option<String>,
+    pub id: String,
+    #[serde(rename = "fbc:metaid")]
+    pub metaid: Option<String>,
+    #[serde(rename = "fbc:sboTerm")]
+    pub sbo_term: Option<String>,
     #[serde(rename = "fbc:type")]
-    pub sense: Option<String>,
+    pub sense: String,
     #[serde(rename = "listOfFluxObjectives", default)]
     pub list_of_flux_objectives: ListOfFluxObjectives,
 }
@@ -214,6 +347,8 @@ pub struct ListOfFluxObjectives {
     pub flux_objectives: Vec<FluxObjective>,
 }
 
+/// Relatively simple container for a model variable weighted by a signed
+/// linear coefficient, defined in the Flux Balance Constraint package.
 #[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct FluxObjective {
     #[serde(rename = "fbc:coefficient")]

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -292,7 +292,7 @@ pub struct Reaction {
 
 /// The Constraint object is a mechanism for stating the assumptions under which
 /// a model is designed to operate.
-/// 
+///
 /// TODO: MathML not integrated
 #[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct Constraint {
@@ -302,14 +302,14 @@ pub struct Constraint {
     pub sbo_term: Option<String>,
 }
 
-/// The Flux Balance Constraints package of SBML defines extensions for the 
-/// model, including the FBC Objective. 
+/// The Flux Balance Constraints package of SBML defines extensions for the
+/// model, including the FBC Objective.
 ///
 /// See the [FBC specification](http://co.mbine.org/specifications/sbml.level-3.version-1.fbc.version-2.release-1.pdf)
 /// for more details.
 ///
 /// # Example
-/// 
+///
 /// ```
 /// use quick_xml::de::from_str;
 /// use rust_sbml::Objective;

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -210,7 +210,7 @@ pub struct Objective {
 
 #[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct ListOfFluxObjectives {
-    #[serde(rename="fluxObjective", default)]
+    #[serde(rename = "fluxObjective", default)]
     pub flux_objectives: Vec<FluxObjective>,
 }
 

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -1,38 +1,36 @@
-use mathml::MathNode;
+// use mathml::MathNode;
 #[cfg(feature = "default")]
 use pyo3::prelude::*;
-use roxmltree::Attribute;
-use roxmltree::Node;
-use serde_derive::Deserialize;
-use std::collections::HashMap;
+use serde::Deserialize;
 
-fn unwrap_optional_str(value: Node<'_, '_>, attribute: &'_ str) -> Option<String> {
-    match value.attribute(attribute) {
-        Some(s) => Some(s.to_owned()),
-        _ => None,
-    }
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct UnitDefinition {
+    pub id: Option<String>,
+    #[serde(rename = "listOfUnits", default)]
+    pub list_of_units: ListOfUnits,
 }
 
-fn unwrap_optional_ns(value: Node<'_, '_>, attribute: (&'_ str, &'_ str)) -> Option<String> {
-    match value.attribute(attribute) {
-        Some(s) => Some(s.to_owned()),
-        _ => None,
-    }
+#[derive(Deserialize, PartialEq, Debug, Default, Clone)]
+pub struct ListOfUnits {
+    #[serde(rename = "unit")]
+    pub units: Vec<Unit>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
-pub enum UnitSidRef {
+pub struct Unit {
+    pub kind: UnitSIdRef,
+    exponent: f64,
+    scale: i64,
+    multiplier: f64,
+}
+
+#[derive(Debug, Deserialize, Hash, PartialEq, Eq, Clone)]
+#[serde(untagged)]
+pub enum UnitSIdRef {
     SIUnit(UnitSId),
     CustomUnit(String),
 }
-impl<T: AsRef<str> + ToString> From<&T> for UnitSidRef {
-    fn from(r: &T) -> Self {
-        match serde_plain::from_str(r.as_ref()) {
-            Ok(r) => Self::SIUnit(r),
-            Err(_) => Self::CustomUnit(r.to_string()),
-        }
-    }
-}
+
 #[derive(Debug, Hash, PartialEq, Eq, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum UnitSId {
@@ -70,307 +68,156 @@ pub enum UnitSId {
     Watt,
     Second,
 }
-#[derive(Debug, Default, PartialEq)]
-
-pub struct ModelUnits {
-    pub substance_units: Option<UnitSidRef>,
-    pub time_units: Option<UnitSidRef>,
-    pub extent_units: Option<UnitSidRef>,
-    pub volume_units: Option<UnitSidRef>,
-    pub area_units: Option<UnitSidRef>,
-    pub length_units: Option<UnitSidRef>,
-    pub conversion_factor: Option<UnitSidRef>,
-}
-
-impl From<&[Attribute<'_>]> for ModelUnits {
-    fn from(value: &[Attribute<'_>]) -> Self {
-        let hmap: HashMap<String, String> = value
-            .iter()
-            .map(|a| (a.name().to_owned(), a.value().to_owned()))
-            .collect();
-        ModelUnits {
-            substance_units: hmap.get("substanceUnits").map(|p| p.into()),
-            time_units: hmap.get("timeUnits").map(|p| p.into()),
-            extent_units: hmap.get("extentUnits").map(|p| p.into()),
-            volume_units: hmap.get("volumeUnits").map(|p| p.into()),
-            area_units: hmap.get("areaUnits").map(|p| p.into()),
-            length_units: hmap.get("lengthUnits").map(|p| p.into()),
-            conversion_factor: hmap.get("conversionFactor").map(|p| p.into()),
-        }
-    }
-}
-#[derive(Debug, PartialEq)]
-pub struct Unit {
-    exponent: f64,
-    scale: i64,
-    multiplier: f64,
-}
-impl From<Node<'_, '_>> for Unit {
-    fn from(value: Node<'_, '_>) -> Self {
-        Unit {
-            exponent: value.attribute("exponent").unwrap().parse().unwrap(),
-            scale: value.attribute("scale").unwrap().parse().unwrap(),
-            multiplier: value.attribute("multiplier").unwrap().parse().unwrap(),
-        }
-    }
-}
-/// Metadata for models
-///
-/// # Example
-///
-/// ```
-/// use roxmltree;
-/// use rust_sbml::Annotation;
-///
-///let anotation: Annotation = roxmltree::Document::parse(
-///     "<model extentUnits='substance' id='e_coli_core' metaid='e_coli_core' name='Escherichia coli str. K-12 substr. MG1655' substanceUnits='substance' timeUnits='time'>",
-/// )
-/// .unwrap()
-/// .descendants()
-/// .filter(|n| n.tag_name().name() == "model")
-/// .map(|n| Annotation::from(n)).next().unwrap();
-/// println!("{:?}", anotation);
-/// assert_eq!(
-///     anotation.name.unwrap(),
-///     "Escherichia coli str. K-12 substr. MG1655".to_string()
-/// );
-/// ```
-#[derive(Debug, Default, PartialEq, Clone)]
-pub struct Annotation {
-    pub id: Option<String>,
-    pub metaid: Option<String>,
-    pub name: Option<String>,
-}
-impl From<Node<'_, '_>> for Annotation {
-    fn from(value: Node<'_, '_>) -> Self {
-        Annotation {
-            id: unwrap_optional_str(value, "id"),
-            metaid: unwrap_optional_str(value, "metaid"),
-            name: unwrap_optional_str(value, "name"),
-        }
-    }
-}
 
 #[cfg_attr(feature = "default", pyclass)]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Compartment {
-    units: Option<UnitSidRef>,
+    units: Option<UnitSIdRef>,
     pub id: String,
     pub name: Option<String>,
     spatial_dimensions: Option<f64>,
     size: Option<f64>,
     constant: bool,
 }
-impl From<Node<'_, '_>> for Compartment {
-    fn from(value: Node<'_, '_>) -> Self {
-        Compartment {
-            spatial_dimensions: value
-                .attribute("spatialDimensions")
-                .map(|p| p.parse().unwrap()),
-            id: value.attribute("id").unwrap().to_owned(),
-            name: unwrap_optional_str(value, "name"),
-            size: value.attribute("size").map(|p| p.parse().unwrap()),
-            constant: value.attribute("constant").unwrap().parse().unwrap(),
-            units: value.attribute("units").map(|p| UnitSidRef::from(&p)),
-        }
-    }
-}
 
+/// A species in SBML refers to a pool of entities that
+/// ⁻ are considered indistinguishable from each other for the purposes of the model;
+/// - may participate in reactions;
+/// - are located in a specific compartment.
 #[cfg_attr(feature = "default", pyclass)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct Specie {
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Species {
+    pub id: String,
     pub compartment: String,
     initial_concentration: Option<f64>,
     initial_amount: Option<f64>,
-    pub id: String,
-    substance_units: Option<UnitSidRef>,
+    substance_units: Option<UnitSIdRef>,
     has_only_substance_units: bool,
     pub boundary_condition: bool,
     pub constant: bool,
     conversion_factor: Option<String>,
 }
-impl<'a> From<Node<'a, 'a>> for Specie {
-    fn from(value: Node<'a, 'a>) -> Self {
-        Specie {
-            compartment: value.attribute("compartment").unwrap().to_owned(),
-            id: value.attribute("id").unwrap().to_owned(),
-            initial_concentration: value
-                .attribute("initialConcentration")
-                .map(|p| p.parse().unwrap()),
-            initial_amount: value.attribute("initialAmount").map(|p| p.parse().unwrap()),
-            substance_units: value
-                .attribute("substanceUnits")
-                .map(|p| UnitSidRef::from(&p)),
-            has_only_substance_units: value
-                .attribute("hasOnlySubstanceUnits")
-                .unwrap()
-                .parse()
-                .unwrap(),
-            boundary_condition: value
-                .attribute("boundaryCondition")
-                .unwrap()
-                .parse()
-                .unwrap(),
-            constant: value.attribute("constant").unwrap().parse().unwrap(),
-            conversion_factor: value.attribute("conversionFactor").map(|r| r.to_owned()),
-        }
-    }
-}
+
 #[cfg_attr(feature = "default", pyclass)]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
+pub struct Parameter {
+    pub id: String,
+    pub value: Option<f64>,
+    units: Option<UnitSIdRef>,
+    pub constant: bool,
+}
+
+/// InitialAssigments provide a way to compute initial values that must be
+/// (using a MathML expression).
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+pub struct InitialAssignment {
+    pub id: Option<String>,
+    pub symbol: String,
+    // pub math: Option<MathNode>,
+    #[serde(rename = "sboTerm", default)]
+    sbo_term: Option<String>,
+}
+
+#[cfg_attr(feature = "default", pyclass)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct SpeciesReference {
     pub species: String,
     pub constant: bool,
+    #[serde(rename = "sboTerm", default)]
     pub sbo_term: Option<String>,
     pub id: Option<String>,
     pub name: Option<String>,
     pub stoichiometry: Option<f64>,
 }
-impl<'a> From<Node<'a, 'a>> for SpeciesReference {
-    fn from(value: Node<'a, 'a>) -> Self {
-        SpeciesReference {
-            species: value.attribute("species").unwrap().to_string(),
-            constant: value.attribute("constant").unwrap().parse().unwrap(),
-            sbo_term: unwrap_optional_str(value, "sboTerm"),
-            id: unwrap_optional_str(value, "id"),
-            name: unwrap_optional_str(value, "name"),
-            stoichiometry: match value.attribute("stoichiometry") {
-                Some(s) => Some(s.parse().unwrap()),
-                None => None,
-            },
-        }
-    }
+
+#[derive(Debug, PartialEq, Clone, Default, Deserialize)]
+pub struct ListOfSpeciesReferences {
+    #[serde(rename = "speciesReference", default = "Vec::new")]
+    pub species_references: Vec<SpeciesReference>,
 }
 
-#[cfg_attr(feature = "default", pyclass)]
-#[derive(Debug, PartialEq, Clone)]
-pub struct Parameter {
-    pub value: Option<f64>,
-    units: Option<UnitSidRef>,
-    pub constant: bool,
-}
-impl<'a> From<Node<'a, 'a>> for Parameter {
-    fn from(value: Node<'a, 'a>) -> Self {
-        Parameter {
-            value: value.attribute("value").map(|p| p.parse().unwrap()),
-            units: value.attribute("units").map(|p| UnitSidRef::from(&p)),
-            constant: value.attribute("constant").unwrap().parse().unwrap(),
-        }
-    }
-}
-#[derive(Debug, PartialEq)]
-pub struct InitialAssignment {
-    pub symbol: String,
-}
-#[derive(Debug, PartialEq, Clone)]
-pub struct ListOfSpecies(pub Vec<SpeciesReference>);
-impl<'a> From<Node<'a, 'a>> for ListOfSpecies {
-    fn from(value: Node<'a, 'a>) -> Self {
-        ListOfSpecies(
-            value
-                .descendants()
-                .filter(|n| n.tag_name().name() == "speciesReference")
-                .map(SpeciesReference::from)
-                .collect(),
-        )
-    }
-}
-
-/// Reaction object as defined by SBML
+/// A reaction in SBML represents any kind of process that can change the
+/// quantity of one or more species in a model. Examples of such processes can
+/// include transformation, transport, molecular interactions, and more.
 /// TODO: implement KineticLaw
 ///
 /// # Example
 ///
 /// ```
-/// use roxmltree;
+/// use quick_xml::de::from_str;
 /// use rust_sbml::Reaction;
 ///
-/// let reactions: Vec<Reaction> = roxmltree::Document::parse(
-///     "<model id='example'><listOfReactions>
-///         <reaction id='J1' reversible='false'>
-///             <listOfReactants>
-///                 <speciesReference species='X0' stoichiometry='2' constant='true'/>
-///     </listOfReactants></reaction></listOfReactions></model>",
+/// let reactions: Reaction = from_str(
+/// "<reaction id='J1' reversible='false' fbc:lowerFluxBound='-20'>
+///         <listOfReactants>
+///             <speciesReference species='X0' stoichiometry='2' constant='true'/>
+/// </listOfReactants></reaction></listOfReactions></model>",
 /// )
-/// .unwrap()
-/// .descendants()
-/// .filter(|n| n.tag_name().name() == "reaction")
-/// .map(|n| Reaction::from(n))
-/// .collect();
+/// .unwrap();
 /// println!("{:?}", reactions);
-/// assert!(
-///     reactions.iter().any(|reaction| reaction
-///         .list_of_reactants
-///         .0
-///         .iter()
-///         .any(|specref| specref.species == "X0"))
-/// );
+/// assert!(reactions
+///     .list_of_reactants
+///     .species_references
+///     .iter()
+///     .any(|specref| specref.species == "X0"));
 /// ```
 #[cfg_attr(feature = "default", pyclass)]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Reaction {
     pub id: String,
-    pub list_of_reactants: ListOfSpecies,
-    pub list_of_products: ListOfSpecies,
+    #[serde(default)]
+    pub list_of_reactants: ListOfSpeciesReferences,
+    #[serde(default)]
+    pub list_of_products: ListOfSpeciesReferences,
     pub reversible: bool,
     pub compartment: Option<String>,
     pub name: Option<String>,
     pub sbo_term: Option<String>,
+    #[serde(rename = "fbc:lowerFluxBound")]
     pub lower_bound: Option<String>,
+    #[serde(rename = "fbc:lowerUpperBound")]
     pub upper_bound: Option<String>,
 }
-impl<'a> From<Node<'a, 'a>> for Reaction {
-    fn from(value: Node<'a, 'a>) -> Self {
-        Reaction {
-            id: value.attribute("id").unwrap().to_owned(),
-            list_of_reactants: match value
-                .children()
-                .find(|n| n.tag_name().name() == "listOfReactants")
-            {
-                Some(n) => ListOfSpecies::from(n),
-                _ => ListOfSpecies(Vec::new()),
-            },
-            list_of_products: match value
-                .children()
-                .find(|n| n.tag_name().name() == "listOfProducts")
-            {
-                Some(n) => ListOfSpecies::from(n),
-                _ => ListOfSpecies(Vec::new()),
-            },
-            reversible: value.attribute("reversible").unwrap().parse().unwrap(),
-            compartment: unwrap_optional_str(value, "compartment"),
-            lower_bound: unwrap_optional_ns(
-                value,
-                (
-                    "http://www.sbml.org/sbml/level3/version1/fbc/version2",
-                    "lowerFluxBound",
-                ),
-            ),
-            upper_bound: unwrap_optional_ns(
-                value,
-                (
-                    "http://www.sbml.org/sbml/level3/version1/fbc/version2",
-                    "upperFluxBound",
-                ),
-            ),
-            name: unwrap_optional_str(value, "name"),
-            sbo_term: unwrap_optional_str(value, "sboTerm"),
-        }
-    }
-}
 
-#[derive(Debug, PartialEq)]
-pub struct Function {
-    math: MathNode,
-}
+// #[derive(Debug, PartialEq)]
+// pub struct Function {
+//     math: MathNode,
+// }
 // #[derive(Debug, PartialEq)]
 // pub enum Rule<'a> {
 //     AlgebraicRule { math: MathNode },
 //     AssignmentRule { math: MathNode, variable: &'a str },
 //     RateRule { math: MathNode, variable: &'a str },
 // }
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Default, Clone)]
 pub struct Constraint {
-    pub math: Option<MathNode>,
+    // pub math: Option<MathNode>,
     pub message: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Default, Clone)]
+pub struct Objective {
+    #[serde(rename = "fbc:id")]
+    pub id: Option<String>,
+    #[serde(rename = "fbc:type")]
+    pub sense: Option<String>,
+    #[serde(rename = "listOfFluxObjectives", default)]
+    pub list_of_flux_objectives: ListOfFluxObjectives,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Default, Clone)]
+pub struct ListOfFluxObjectives {
+    #[serde(rename="fluxObjective", default)]
+    pub flux_objectives: Vec<FluxObjective>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Default, Clone)]
+pub struct FluxObjective {
+    #[serde(rename = "fbc:coefficient")]
+    pub coefficient: Option<f64>,
+    #[serde(rename = "fbc:reaction")]
+    pub reaction: Option<String>,
 }

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -132,9 +132,12 @@ pub struct Compartment {
 ///     hasOnlySubstanceUnits='false' boundaryCondition='false' constant='false'/>"
 /// )
 /// .unwrap();
+/// assert_eq!(species[0].id, "Glucose");
 /// assert_eq!(species[0].compartment, "cell");
 /// assert_eq!(species[0].initial_concentration.unwrap() as u8, 4);
 /// assert!(!species[0].constant);
+/// assert!(!species[0].boundary_condition);
+/// assert!(!species[0].has_only_substance_units);
 /// ```
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -212,6 +215,8 @@ pub struct InitialAssignment {
 ///     .iter();
 /// assert!(specs_ref
 ///     .any(|specref| specref.species == "X0"));
+/// assert!(specs_ref
+///     .any(|specref| {println!("{:?}", specref); specref.stoichiometry.unwrap() as i32 == 1}));
 /// assert!(specs_ref
 ///     .all(|specref| specref.constant));
 /// ```

--- a/src/base_types.rs
+++ b/src/base_types.rs
@@ -3,7 +3,7 @@
 use pyo3::prelude::*;
 use serde::Deserialize;
 
-/// Combination of [`Unit`](./rust_sbml/struct.Unit.html).
+/// Combination of [`Unit`](../struct.Unit.html).
 ///
 /// The approach to defining units in SBML is compositional; for example,
 /// metre second −2 is constructed by combining
@@ -23,7 +23,7 @@ pub struct ListOfUnits {
 }
 
 /// A Unit object represents a reference to a (possibly transformed) base unit
-/// (see [UnitSIdRef](./rust_sbml/enum.UnitSIdRef.html).
+/// (see [UnitSIdRef](./enum.UnitSIdRef.html).
 ///
 /// The attribute kind indicates the base unit, whereas the attributes
 /// exponent, scale and multiplier define how the base unit is being transformed.
@@ -35,7 +35,7 @@ pub struct Unit {
     pub multiplier: f64,
 }
 
-/// SBML provides predefined base units, gathered in [`UnitSId`](./rust_sbml/enum.UnitSId.html).
+/// SBML provides predefined base units, gathered in [`UnitSId`](./enum.UnitSId.html).
 /// Alternatively, one can use arbitrary `CustomUnit`s.
 #[derive(Debug, Deserialize, Hash, PartialEq, Eq, Clone)]
 #[serde(untagged)]
@@ -304,6 +304,9 @@ pub struct Constraint {
 
 /// The Flux Balance Constraints package of SBML defines extensions for the 
 /// model, including the FBC Objective. 
+///
+/// See the [FBC specification](http://co.mbine.org/specifications/sbml.level-3.version-1.fbc.version-2.release-1.pdf)
+/// for more details.
 ///
 /// # Example
 /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@
 mod base_types;
 mod list_of;
 mod model;
-#[cfg(feature = "default")]
 #[cfg(not(tarpaulin_include))]
+#[cfg(feature = "default")]
 mod pyo;
 
 pub use base_types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub use base_types::{
     Unit, UnitSId, UnitSIdRef,
 };
 
-pub use model::{parse_document, Model, ModelUnits};
+pub use model::{parse_document, Model, ModelRaw, ModelUnits};
 #[cfg(feature = "default")]
 pub use pyo::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,8 @@ mod model;
 mod pyo;
 
 pub use base_types::{
-    Compartment, Constraint, InitialAssignment, Parameter, Reaction, Species, SpeciesReference,
-    Unit, UnitSId, UnitSIdRef, Objective
+    Compartment, Constraint, InitialAssignment, Objective, Parameter, Reaction, Species,
+    SpeciesReference, Unit, UnitSId, UnitSIdRef,
 };
 
 pub use model::{parse_document, Model, ModelRaw, ModelUnits};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ mod pyo;
 
 pub use base_types::{
     Compartment, Constraint, InitialAssignment, Parameter, Reaction, Species, SpeciesReference,
-    Unit, UnitSId, UnitSIdRef,
+    Unit, UnitSId, UnitSIdRef, Objective
 };
 
 pub use model::{parse_document, Model, ModelRaw, ModelUnits};

--- a/src/list_of.rs
+++ b/src/list_of.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 
 use super::base_types::{
-    Compartment, Constraint, InitialAssignment, Parameter, Reaction, Species, UnitDefinition, Objective
+    Compartment, Constraint, InitialAssignment, Objective, Parameter, Reaction, Species,
+    UnitDefinition,
 };
 
 #[derive(Deserialize, PartialEq, Debug, Default)]
@@ -50,4 +51,3 @@ pub struct ListOfObjectives {
     #[serde(rename = "objective", default)]
     pub objectives: Vec<Objective>,
 }
-

--- a/src/list_of.rs
+++ b/src/list_of.rs
@@ -1,0 +1,53 @@
+use serde::Deserialize;
+
+use super::base_types::{
+    Compartment, Constraint, InitialAssignment, Parameter, Reaction, Species, UnitDefinition, Objective
+};
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfUnitDefinitions {
+    #[serde(rename = "unitDefinition", default)]
+    pub unit_definitions: Vec<UnitDefinition>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfCompartments {
+    #[serde(rename = "compartment", default)]
+    pub compartments: Vec<Compartment>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfSpecies {
+    pub species: Vec<Species>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfReactions {
+    #[serde(rename = "reaction", default)]
+    pub reactions: Vec<Reaction>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfParameters {
+    #[serde(rename = "parameter", default)]
+    pub parameters: Vec<Parameter>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfInitialAssignments {
+    #[serde(rename = "initialAssigment", default)]
+    pub initial_assignments: Vec<InitialAssignment>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfConstraints {
+    #[serde(rename = "constraints", default)]
+    pub constraints: Vec<Constraint>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct ListOfObjectives {
+    #[serde(rename = "objective", default)]
+    pub objectives: Vec<Objective>,
+}
+

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,6 +11,7 @@ use super::list_of::*;
 /// SBML model as defined in the [SBML Level 3 Version 2 core](http://sbml.org/Documents/Specifications).
 ///
 /// Extended with [fbc plugin](http://sbml.org/Documents/Specifications/SBML_Level_3/Packages/fbc)
+///
 /// # Example
 ///
 /// ```
@@ -67,6 +68,8 @@ struct SBML {
     model: ModelRaw,
 }
 
+/// Bucket struct to hold all units defined on the top level of 
+/// [`ModelRaw`](./rust_sbml/struct.ModelRaw.html).
 #[derive(Debug, Default, PartialEq)]
 pub struct ModelUnits {
     pub substance_units: Option<UnitSIdRef>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -96,9 +96,9 @@ impl From<&ModelRaw> for ModelUnits {
 }
 
 type HL<T> = HashMap<String, T>;
-/// Commodity abstraction over the SBML specification. It traverse each top-level
-/// listOF_ and provides `HashMaps<id, object>´ instead. In addition the model
-/// units are gathered in an [`ModelUnits`](./rust_sbml/struct.ModelUnits.html) struct.
+/// Abstraction over the SBML specification. It traverses each top-level
+/// listOF_ and provides `HashMaps<id, object>` instead. In addition the model
+/// units are gathered in an [`ModelUnits`](./struct.ModelUnits.html) struct.
 ///
 /// # Example
 ///
@@ -274,6 +274,7 @@ impl Model {
     }
 }
 
+/// Shortcut to [`Model::parse`](./struct.Model.html).
 pub fn parse_document(doc: &str) -> Result<Model, Box<dyn std::error::Error>> {
     Model::parse(doc)
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -180,8 +180,7 @@ impl Model {
     /// println!("{:?}", document.get_list_of_reactions())
     /// ```
     pub fn parse(doc: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let raw_model: SBML = quick_xml::de::from_str(doc)?;
-        let raw_model = raw_model.model;
+        let raw_model = ModelRaw::parse(doc)?;
         // Units used by the model itself
         let model_units: ModelUnits = ModelUnits::from(&raw_model);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -68,7 +68,7 @@ struct SBML {
     model: ModelRaw,
 }
 
-/// Bucket struct to hold all units defined on the top level of 
+/// Bucket struct to hold all units defined on the top level of
 /// [`ModelRaw`](./rust_sbml/struct.ModelRaw.html).
 #[derive(Debug, Default, PartialEq)]
 pub struct ModelUnits {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,11 +1,73 @@
 #[cfg(feature = "default")]
 use pyo3::prelude::*;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 use super::base_types::{
-    Annotation, Compartment, Constraint, InitialAssignment, ModelUnits, Parameter, Reaction,
-    Specie, Unit, UnitSId,
+    Compartment, Constraint, InitialAssignment, Parameter, Reaction, Species, Unit, UnitSIdRef,
 };
+use super::list_of::*;
+
+#[derive(Deserialize, Debug, Default, PartialEq)]
+#[serde(rename = "model", rename_all = "camelCase")]
+pub struct ModelRaw {
+    pub id: Option<String>,
+    pub metaid: Option<String>,
+    pub name: Option<String>,
+    pub substance_units: Option<UnitSIdRef>,
+    pub time_units: Option<UnitSIdRef>,
+    pub extent_units: Option<UnitSIdRef>,
+    pub volume_units: Option<UnitSIdRef>,
+    pub area_units: Option<UnitSIdRef>,
+    pub length_units: Option<UnitSIdRef>,
+    pub conversion_factor: Option<UnitSIdRef>,
+    #[serde(default)]
+    pub list_of_unit_definitions: ListOfUnitDefinitions,
+    #[serde(default)]
+    pub list_of_compartments: ListOfCompartments,
+    #[serde(default)]
+    pub list_of_species: ListOfSpecies,
+    #[serde(default)]
+    pub list_of_parameters: ListOfParameters,
+    #[serde(default)]
+    pub list_of_initial_assignments: ListOfInitialAssignments,
+    #[serde(default)]
+    pub list_of_reactions: ListOfReactions,
+    #[serde(default)]
+    pub list_of_constraints: ListOfConstraints,
+    #[serde(rename = "listOfObjectives", default)]
+    pub list_of_objectives: Option<ListOfObjectives>,
+}
+
+#[derive(Deserialize, Debug, Default, PartialEq)]
+struct SBML {
+    model: ModelRaw,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct ModelUnits {
+    pub substance_units: Option<UnitSIdRef>,
+    pub time_units: Option<UnitSIdRef>,
+    pub extent_units: Option<UnitSIdRef>,
+    pub volume_units: Option<UnitSIdRef>,
+    pub area_units: Option<UnitSIdRef>,
+    pub length_units: Option<UnitSIdRef>,
+    pub conversion_factor: Option<UnitSIdRef>,
+}
+
+impl From<&ModelRaw> for ModelUnits {
+    fn from(raw_model: &ModelRaw) -> Self {
+        Self {
+            substance_units: raw_model.substance_units.clone(),
+            time_units: raw_model.time_units.clone(),
+            extent_units: raw_model.extent_units.clone(),
+            volume_units: raw_model.volume_units.clone(),
+            area_units: raw_model.area_units.clone(),
+            length_units: raw_model.length_units.clone(),
+            conversion_factor: raw_model.conversion_factor.clone(),
+        }
+    }
+}
 
 type HL<T> = HashMap<String, T>;
 /// Struct that holds the entire SBML document (non-comprehensive)
@@ -18,29 +80,32 @@ type HL<T> = HashMap<String, T>;
 ///
 /// let ecoli = fs::read_to_string("examples/EcoliCore.xml").unwrap();
 /// let document = Model::parse(&ecoli).unwrap();
+/// println!("{:?}", document.objectives);
 /// assert_eq!(
 ///     document
 ///         .objectives
+///         .unwrap()
 ///         .iter()
 ///         .map(|reac_id| reac_id.to_owned())
-///         .next()
-///         .unwrap(),
-///     "R_BIOMASS_Ecoli_core_w_GAM"
+///         .next(),
+///     Some("R_BIOMASS_Ecoli_core_w_GAM".to_string())
 /// );
 /// ```
 #[cfg_attr(feature = "default", pyclass)]
 #[derive(Debug, Default, PartialEq)]
 pub struct Model {
+    pub id: Option<String>,
+    pub metaid: Option<String>,
+    pub name: Option<String>,
     pub model_units: ModelUnits,
     pub initial_assignments: HL<InitialAssignment>,
     pub parameters: HL<Parameter>,
-    pub species: HL<Specie>,
+    pub species: HL<Species>,
     pub reactions: HL<Reaction>,
     pub compartments: HL<Compartment>,
-    pub unit_definitions: HL<HashMap<UnitSId, Unit>>,
+    pub unit_definitions: HL<HashMap<UnitSIdRef, Unit>>,
     pub constraints: Vec<Constraint>,
-    pub objectives: Vec<String>,
-    pub annotation: Annotation,
+    pub objectives: Option<Vec<String>>,
 }
 
 impl Model {
@@ -59,7 +124,7 @@ impl Model {
     /// let document = Model::parse(&ecoli).unwrap();
     /// println!("{:?}", document.get_list_of_compartments())
     /// ```
-    pub fn get_list_of_species(&self) -> Vec<&Specie> {
+    pub fn get_list_of_species(&self) -> Vec<&Species> {
         self.species.iter().map(|(_key, val)| val).collect()
     }
     /// Emulating the API of libSBML
@@ -89,124 +154,89 @@ impl Model {
     /// let document = Model::parse(&ecoli).unwrap();
     /// println!("{:?}", document.get_list_of_reactions())
     /// ```
-    pub fn parse(doc: &str) -> Result<Self, roxmltree::Error> {
-        let res = roxmltree::Document::parse(doc)?;
-        let raw_model = res
-            .descendants()
-            .find(|n| n.tag_name().name() == "model")
-            .unwrap();
-
+    pub fn parse(doc: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let raw_model: SBML = quick_xml::de::from_str(doc)?;
+        let raw_model = raw_model.model;
         // Units used by the model itself
-        let model_units: ModelUnits = ModelUnits::from(raw_model.attributes());
+        let model_units: ModelUnits = ModelUnits::from(&raw_model);
 
         // Unit definitions
-        let unit_definitions: HashMap<String, HashMap<UnitSId, Unit>> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "unitDefinition")
-            .map(|r| {
+        let unit_definitions: HashMap<String, HashMap<UnitSIdRef, Unit>> = raw_model
+            .list_of_unit_definitions
+            .unit_definitions
+            .iter()
+            .map(|unit_def| {
                 (
-                    r.attribute("id").unwrap().to_owned(),
-                    r.descendants()
-                        .filter(|n| n.tag_name().name() == "unit")
-                        .map(|r| {
-                            (
-                                r.attribute("kind")
-                                    .map(serde_plain::from_str)
-                                    .unwrap()
-                                    .unwrap(),
-                                Unit::from(r),
-                            )
-                        })
+                    (*unit_def).to_owned().id.unwrap(),
+                    unit_def
+                        .list_of_units
+                        .units
+                        .iter()
+                        .map(|unit| (unit.kind.to_owned(), unit.to_owned()))
                         .collect(),
                 )
             })
             .collect();
-        let annotation: Annotation = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "model")
-            .map(Annotation::from)
-            .next()
-            .unwrap();
         // Compartments
         let compartments: HashMap<String, Compartment> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "compartment")
-            .map(|n| (n.attribute("id").unwrap().to_owned(), Compartment::from(n)))
+            .list_of_compartments
+            .compartments
+            .iter()
+            .map(|n| (n.id.to_owned(), n.to_owned()))
             .collect();
         // Species
-        let species: HashMap<String, Specie> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "species")
-            .map(|n| (n.attribute("id").unwrap().to_owned(), Specie::from(n)))
+        let species: HashMap<String, Species> = raw_model
+            .list_of_species
+            .species
+            .iter()
+            .map(|n| (n.id.to_owned(), n.to_owned()))
             .collect();
         // Parameters
         let parameters: HashMap<String, Parameter> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "parameter")
-            .map(|n| (n.attribute("id").unwrap().to_owned(), Parameter::from(n)))
+            .list_of_parameters
+            .parameters
+            .iter()
+            .map(|n| (n.id.to_owned(), n.to_owned()))
             .collect();
         // Initial assignments
         let initial_assignments: HashMap<String, InitialAssignment> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "initialAssignment")
-            .map(|n| {
-                (
-                    n.attribute("id").unwrap().to_owned(),
-                    InitialAssignment {
-                        symbol: n.attribute("symbol").unwrap().to_owned(),
-                    },
-                )
-            })
+            .list_of_initial_assignments
+            .initial_assignments
+            .iter()
+            .map(|n| (n.id.to_owned().unwrap(), (*n).to_owned()))
             .collect();
         // Reactions
         let reactions: HashMap<String, Reaction> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "reaction")
-            .map(|n| (n.attribute("id").unwrap().to_owned(), Reaction::from(n)))
+            .list_of_reactions
+            .reactions
+            .iter()
+            .map(|n| (n.id.to_owned(), n.to_owned()))
             .collect();
 
         // Constraints
-        let constraints: Vec<Constraint> = raw_model
-            .descendants()
-            .filter(|n| n.tag_name().name() == "constraint")
-            .map(|n| Constraint {
-                math: n
-                    .descendants()
-                    .find(|n| n.tag_name().name() == "math")
-                    .map(mathml::parse_node),
-                message: n
-                    .descendants()
-                    .find(|n| n.tag_name().name() == "message")
-                    .unwrap()
-                    .children()
-                    .map(|n| n.text().unwrap().trim().to_owned())
-                    .collect::<String>(),
-            })
-            .collect();
-        let objectives: Vec<String> = raw_model
-            .descendants()
-            .filter(|n| {
-                n.tag_name()
-                    == roxmltree::ExpandedName::from((
-                        "http://www.sbml.org/sbml/level3/version1/fbc/version2",
-                        "fluxObjective",
-                    ))
-            })
-            .map(|n| {
-                n.attribute((
-                    "http://www.sbml.org/sbml/level3/version1/fbc/version2",
-                    "reaction",
-                ))
-                .unwrap()
-                .to_owned()
-            })
-            .collect();
-
+        let constraints: Vec<Constraint> = raw_model.list_of_constraints.constraints;
+        println!("{:?}", &raw_model.list_of_objectives);
+        let objectives: Option<Vec<String>> = match raw_model.list_of_objectives {
+            Some(objs) => Some(
+                objs.objectives
+                    .iter()
+                    .flat_map(|n| {
+                        (*n).list_of_flux_objectives
+                            .flux_objectives
+                            .iter()
+                            .map(|fr| fr.reaction.to_owned().unwrap())
+                    })
+                    .collect(),
+            ),
+            None => None,
+        };
         Ok(Model {
+            id: raw_model.id,
+            metaid: raw_model.metaid,
+            name: raw_model.name,
             model_units,
             parameters,
             initial_assignments,
-            annotation,
             species,
             reactions,
             compartments,
@@ -217,34 +247,6 @@ impl Model {
     }
 }
 
-pub fn parse_document(doc: &str) -> Result<Model, roxmltree::Error> {
+pub fn parse_document(doc: &str) -> Result<Model, Box<dyn std::error::Error>> {
     Model::parse(doc)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_name() {
-        let reactions: Vec<Reaction> = roxmltree::Document::parse(
-            "<model id='example'><listOfReactions>
-                 <reaction id='J1' reversible='false'>
-                     <listOfReactants>
-                         <speciesReference species='X0' stoichiometry='2' constant='true'/>
-                         <reaction id='J2' reversible='false'>
-                             <listOfReactants>
-                             <speciesReference species='CAP' stoichiometry='2' constant='true'/>
-                             <speciesReference species='ZOOM' stoichiometry='-2' constant='true'/>
-                     </listOfReactants></reaction>
-             </listOfReactants></reaction></listOfReactions></model>",
-        )
-        .unwrap()
-        .descendants()
-        .filter(|n| n.tag_name().name() == "reaction")
-        .map(Reaction::from)
-        .collect();
-        println!("{:?}", reactions);
-        assert_eq!(reactions[1].list_of_reactants.0.len(), 2);
-    }
 }

--- a/src/pyo.rs
+++ b/src/pyo.rs
@@ -117,7 +117,7 @@ impl Model {
     fn getObjectives(&self) -> PyResult<Vec<String>> {
         Ok(match self.objectives.to_owned() {
             Some(o) => o,
-            _ => Vec::new()
+            _ => Vec::new(),
         })
     }
     #[getter]

--- a/src/pyo.rs
+++ b/src/pyo.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
-use super::{Compartment, Model, Parameter, Reaction, Specie, SpeciesReference};
+use super::{Compartment, Model, Parameter, Reaction, Species, SpeciesReference};
 use pyo3::prelude::*;
 
 #[pymethods]
-impl Specie {
+impl Species {
     #[getter]
     fn id(&self) -> PyResult<String> {
         Ok(self.id.to_owned())
@@ -42,10 +42,10 @@ impl Reaction {
         })
     }
     fn getListOfReactants(&self) -> PyResult<Vec<SpeciesReference>> {
-        Ok(self.list_of_reactants.to_owned().0)
+        Ok(self.list_of_reactants.to_owned().species_references)
     }
     fn getListOfProducts(&self) -> PyResult<Vec<SpeciesReference>> {
-        Ok(self.list_of_products.to_owned().0)
+        Ok(self.list_of_products.to_owned().species_references)
     }
     fn getLowerFluxBound(&self) -> PyResult<String> {
         Ok(match self.lower_bound.to_owned() {
@@ -105,7 +105,7 @@ impl Model {
             .map(|(_, n)| n.to_owned())
             .collect())
     }
-    fn getListOfSpecies(&self) -> PyResult<Vec<Specie>> {
+    fn getListOfSpecies(&self) -> PyResult<Vec<Species>> {
         Ok(self.species.iter().map(|(_, n)| n.to_owned()).collect())
     }
     fn getListOfReactions(&self) -> PyResult<Vec<Reaction>> {
@@ -115,25 +115,28 @@ impl Model {
         Ok(self.parameters[&query].to_owned())
     }
     fn getObjectives(&self) -> PyResult<Vec<String>> {
-        Ok(self.objectives.to_owned())
+        Ok(match self.objectives.to_owned() {
+            Some(o) => o,
+            _ => Vec::new()
+        })
     }
     #[getter]
     fn id(&self) -> PyResult<String> {
-        Ok(match self.annotation.id.to_owned() {
+        Ok(match self.id.to_owned() {
             Some(s) => s,
             None => "".to_string(),
         })
     }
     #[getter]
     fn metaid(&self) -> PyResult<String> {
-        Ok(match self.annotation.metaid.to_owned() {
+        Ok(match self.metaid.to_owned() {
             Some(s) => s,
             None => "".to_string(),
         })
     }
     #[getter]
     fn name(&self) -> PyResult<String> {
-        Ok(match self.annotation.name.to_owned() {
+        Ok(match self.name.to_owned() {
             Some(s) => s,
             None => "".to_string(),
         })
@@ -144,7 +147,7 @@ impl Model {
 fn rust_sbml(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Model>()?;
     m.add_class::<Reaction>()?;
-    m.add_class::<Specie>()?;
+    m.add_class::<Species>()?;
     m.add_class::<SpeciesReference>()?;
     m.add_class::<Compartment>()?;
     Ok(())

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,75 +1,20 @@
-use mathml::BuiltinOp::*;
-use mathml::MathNode::*;
-use mathml::NumType::*;
-use rust_sbml::{parse_document, Constraint, Model, ModelUnits, UnitSId, UnitSidRef};
-use std::collections::HashMap;
-#[test]
-fn test_constraints() {
-    let unit_type: HashMap<String, String> = vec![(
-        "http://www.sbml.org/sbml/level3/version2/core:units".to_owned(),
-        "mole".to_owned(),
-    )]
-    .into_iter()
-    .collect();
-    let example = include_str!("test_constraint.xml");
-    let res = parse_document(example).unwrap();
-    let expect = Model {
-        model_units: ModelUnits {
-            time_units: Some(UnitSidRef::SIUnit(UnitSId::Second)),
-            substance_units: Some(UnitSidRef::SIUnit(UnitSId::Mole)),
-            extent_units: Some(UnitSidRef::SIUnit(UnitSId::Mole)),
-            volume_units: None,
-            area_units: None,
-            length_units: None,
-            conversion_factor: None,
-        },
+use rust_sbml::{parse_document, Model, ModelUnits, UnitSId, UnitSIdRef};
 
-        constraints: vec![Constraint {
-            math: Some(Root(vec![Apply(vec![
-                Op(and),
-                Apply(vec![
-                    Op(lt),
-                    Cn {
-                        num_type: Real(1.0),
-                        base: 10,
-                        definition_url: None,
-                        encoding: None,
-                        attributes: Some(unit_type.clone()),
-                    },
-                    Ci(vec![Text("S1".to_owned())]),
-                ]),
-                Apply(vec![
-                    Op(lt),
-                    Ci(vec![Text("S1".to_owned())]),
-                    Cn {
-                        num_type: Real(100.0),
-                        base: 10,
-                        definition_url: None,
-                        encoding: None,
-                        attributes: Some(unit_type),
-                    },
-                ]),
-            ])])),
-            message: "Species S1 is out of range.".to_owned(),
-        }],
-        ..Default::default()
-    };
-    assert_eq!(res, expect);
-}
 #[test]
 fn test_simple() {
     let example = include_str!("test_simple.xml");
-    let res = parse_document(example).unwrap();
+    let res = parse_document(example);
+    assert!(res.is_ok());
     let expect = Model {
         model_units: ModelUnits {
-            time_units: Some(UnitSidRef::SIUnit(UnitSId::Second)),
-            substance_units: Some(UnitSidRef::SIUnit(UnitSId::Mole)),
-            extent_units: Some(UnitSidRef::SIUnit(UnitSId::Mole)),
+            time_units: Some(UnitSIdRef::SIUnit(UnitSId::Second)),
+            substance_units: Some(UnitSIdRef::SIUnit(UnitSId::Mole)),
+            extent_units: Some(UnitSIdRef::SIUnit(UnitSId::Mole)),
             ..Default::default()
         },
         ..Default::default()
     };
-    assert_eq!(res, expect)
+    assert_eq!(res.unwrap(), expect)
 }
 
 #[test]
@@ -79,6 +24,7 @@ fn from_genre() {
     assert_eq!(
         model
             .objectives
+            .unwrap()
             .iter()
             .map(|reac_id| reac_id.to_owned())
             .next()


### PR DESCRIPTION
Related #6 
### Description
Move from [roxmltree](https://github.com/RazrFalcon/roxmltree) to [quick-xml](https://github.com/tafia/quick-xml). 

### TODO
- [x] Move to quick-xml.
- [ ] Mattml: it is a problem since that module relies on roxmltree and doesn't implement `Deserialize`.
- [x] PyO3.